### PR TITLE
Fix: Update runtime dependencies for rust

### DIFF
--- a/src/multilspy/language_servers/rust_analyzer/runtime_dependencies.json
+++ b/src/multilspy/language_servers/rust_analyzer/runtime_dependencies.json
@@ -5,7 +5,7 @@
             "id": "RustAnalyzer",
             "description": "RustAnalyzer for macOS (arm64)",
             "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-10-09/rust-analyzer-aarch64-apple-darwin.gz",
-            "platformId": "linux-arm64",
+            "platformId": "osx-arm64",
             "archiveType": "gz",
             "binaryName": "rust_analyzer"
         },

--- a/src/multilspy/language_servers/rust_analyzer/runtime_dependencies.json
+++ b/src/multilspy/language_servers/rust_analyzer/runtime_dependencies.json
@@ -1,11 +1,27 @@
 {
     "_description": "Used to download the runtime dependencies for running RustAnalyzer. Obtained from https://github.com/rust-lang/rust-analyzer/releases",
     "runtimeDependencies": [
-                {
+        {
             "id": "RustAnalyzer",
-            "description": "RustAnalyzer for Linux (x64)",
+            "description": "RustAnalyzer for macOS (arm64)",
+            "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-10-09/rust-analyzer-aarch64-apple-darwin.gz",
+            "platformId": "linux-arm64",
+            "archiveType": "gz",
+            "binaryName": "rust_analyzer"
+        },
+        {
+            "id": "RustAnalyzer",
+            "description": "RustAnalyzer for macOS (x64)",
             "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-10-09/rust-analyzer-aarch64-apple-darwin.gz",
             "platformId": "osx-arm64",
+            "archiveType": "gz",
+            "binaryName": "rust_analyzer"
+        },
+        {
+            "id": "RustAnalyzer",
+            "description": "RustAnalyzer for Linux (arm64)",
+            "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-10-09/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+            "platformId": "linux-arm64",
             "archiveType": "gz",
             "binaryName": "rust_analyzer"
         },

--- a/src/multilspy/language_servers/rust_analyzer/runtime_dependencies.json
+++ b/src/multilspy/language_servers/rust_analyzer/runtime_dependencies.json
@@ -11,14 +11,6 @@
         },
         {
             "id": "RustAnalyzer",
-            "description": "RustAnalyzer for macOS (x64)",
-            "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-10-09/rust-analyzer-aarch64-apple-darwin.gz",
-            "platformId": "osx-arm64",
-            "archiveType": "gz",
-            "binaryName": "rust_analyzer"
-        },
-        {
-            "id": "RustAnalyzer",
             "description": "RustAnalyzer for Linux (arm64)",
             "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-10-09/rust-analyzer-aarch64-unknown-linux-gnu.gz",
             "platformId": "linux-arm64",


### PR DESCRIPTION
- add platform "linux-arm64"